### PR TITLE
Fix : 필터 적용 후 에러 발생

### DIFF
--- a/src/main/java/com/hoin/boardStudy/board/config/filter/LoginCheck.java
+++ b/src/main/java/com/hoin/boardStudy/board/config/filter/LoginCheck.java
@@ -27,21 +27,15 @@ public class LoginCheck implements Filter {
         String requestURI = httpRequest.getRequestURI();
 
         HttpSession session = httpRequest.getSession();
-        
-        log.info("인증 필터 시작");
+
         if(isLoginCheckPath(requestURI)) {
-            log.info("인증 필터 실행");
             if (session == null || session.getAttribute("user") == null) {
                 httpResponse.sendRedirect(httpRequest.getContextPath() + LOGIN_URL);
             }
-
-            // 필터를 더는 진행하지 않는다.
-            return;
         }
 
         // 다음 필터가 있으면 필터를 호출, 없으면 서블릿을 호출.
         chain.doFilter(request, response);
-        log.info("인증 필터 종료");
     }
 
     private boolean isLoginCheckPath(String requestURI) {


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 필터 적용 후 세션 값이 필요한 페이지들이 제대로 출력되지 않는 현상 발생

# 어떻게 해결했나요?
```java
if(isLoginCheckPath(requestURI)) {
            if (session == null || session.getAttribute("user") == null) {
                httpResponse.sendRedirect(httpRequest.getContextPath() + LOGIN_URL);
            }
            return; // if 문 안에 있던 return; 코드 제거
        }
        // 다음 필터가 있으면 필터를 호출, 없으면 서블릿을 호출.
        chain.doFilter(request, response);

```
+ return; 을 써줘야 필터 종료가 된다고 해서 썼었는데 저 코드 때문에 ``chain.doFilter`` 코드가 동작하지 않음.
+ 그래서 지웠어용

## Attachment
