### PR TITLE
feature : session관리 redis 설정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,16 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- spring에서 redis에 대한 의존성 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <!-- spring에서 redis를 session storage로 사용하기 위한 의존성 -->
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-data-redis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/hoin/boardStudy/BoardApplication.java
+++ b/src/main/java/com/hoin/boardStudy/BoardApplication.java
@@ -2,7 +2,9 @@ package com.hoin.boardStudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @SpringBootApplication
 public class BoardApplication {
 

--- a/src/main/java/com/hoin/boardStudy/board/config/RedisConfigure.java
+++ b/src/main/java/com/hoin/boardStudy/board/config/RedisConfigure.java
@@ -1,0 +1,37 @@
+package com.hoin.boardStudy.board.config;
+
+import com.hoin.boardStudy.util.RedisConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfigure {
+
+    private final RedisConfig redisConfig;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(redisConfig.getHost());
+        configuration.setPort(redisConfig.getPort());
+        return new LettuceConnectionFactory(configuration);
+    }
+}

--- a/src/main/java/com/hoin/boardStudy/board/dto/BoardSaveRequest.java
+++ b/src/main/java/com/hoin/boardStudy/board/dto/BoardSaveRequest.java
@@ -5,13 +5,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardSaveRequest {
+public class BoardSaveRequest implements Serializable {
     private int boardId; // 글 번호
     private String writer; // 작성자
     private String title; // 제목

--- a/src/main/java/com/hoin/boardStudy/user/dto/User.java
+++ b/src/main/java/com/hoin/boardStudy/user/dto/User.java
@@ -2,13 +2,14 @@ package com.hoin.boardStudy.user.dto;
 
 import lombok.*;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 
 @Getter @Setter @ToString
 @NoArgsConstructor // 파라메터가 없는 생성자를 생성한다. (기본 생성자)
 @AllArgsConstructor // 클래스에 존재하는 모든 필드에 대한 생성자를 자동으로 생성한다.
-public class User {
+public class User implements Serializable {
 
     private String userId;
     private String password;

--- a/src/main/java/com/hoin/boardStudy/util/RedisConfig.java
+++ b/src/main/java/com/hoin/boardStudy/util/RedisConfig.java
@@ -1,0 +1,15 @@
+package com.hoin.boardStudy.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spring.redis")
+@Getter
+@Setter
+public class RedisConfig {
+    private String host;
+    private int port;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,12 +4,18 @@ mybatis:
     type-aliases-package: com.hoin.boardStudy
     config-location: classpath:mybatis-config.xml
     
-## 파일 크기 설정
+# 파일 크기 설정
 spring:
     servlet:
         multipart:
             max-file-size: 10MB
             max-request-size: 50MB
+# redis 설정
+    session:
+      storage-type: redis
+    redis:
+      host: dev.donghyeon.dev
+      port: 6379
 
 
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* session 관리를 In-Memory 인 Redis로 관리

# 어떻게 해결했나요?
1. redis 다운로드
2. pom.xml 에 redis 의존성 추가
3. RedisConfigure (템플릿, 커넥션) 코드 작성
4. application에 @EnableRedisHttpSession 추가
5. @ConfigurationProperties 사용, @Value사용 지양


++ 추가

+ 글 작성을 해보니 에러가 발생하여 에러 내용 찾아보니 
redis는 hash를 사용하기 때문에
객체에 직렬화를 해줄 필요가 있다고 해서 ``User``, ``BoardSaveRequest`` 객체에 ``implement Serializable``을 추가해주었습니다.

## Attachment
* https://velog.io/@albaneo0724/Spring-Redis%EB%A5%BC-session-storage%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
* https://oingdaddy.tistory.com/311

+ sessionId가 같은 모습
![8080](https://user-images.githubusercontent.com/95499211/165026923-fb581068-3bdf-4b20-935d-b57ab53e2d5c.jpg)
![8082](https://user-images.githubusercontent.com/95499211/165026928-db73e5b6-a459-428a-8542-29fe5f532780.jpg)