### PR TITLE
Error : 페이지네이션 개선

### DIFF
--- a/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
+++ b/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
@@ -42,6 +42,9 @@ public class BoardController {
         Integer pageSize = pageInfo.getPageSize();
 
         PageHandler pageHandler = new PageHandler(totalCount, page, pageSize);
+        // 사용자에게 입력받은 값이 아닌 pageHandler 로직에 의해 구해진 page, pageSize 사용
+        page = pageHandler.getPage();
+        pageSize = pageHandler.getPageSize();
 
         Map<String, Integer> map = new HashMap();
         map.put("offset", (page-1) * pageSize);

--- a/src/main/java/com/hoin/boardStudy/board/dto/PageHandler.java
+++ b/src/main/java/com/hoin/boardStudy/board/dto/PageHandler.java
@@ -21,14 +21,24 @@ public class PageHandler {
     private boolean showNext; // 다음 페이지 링크 포함 여부
 
     public PageHandler(int totalCount, int page, int pageSize) {
+
+        // pageSize Max 값 제한
+        if(pageSize > 20) pageSize = 5;
+        // totalPage 먼저 구하기
+        totalPage = (int)Math.ceil(totalCount / (double)pageSize);
+        // page Max값을 마지막 페이지로 설정
+        if(page > totalPage) page = totalPage;
+
         this.totalCount = totalCount;
         this.page = page;
         this.pageSize = pageSize;
 
-        totalPage = (int)Math.ceil(totalCount / (double)pageSize);
         beginPage = (((int)Math.ceil(page / (double)naviSize))-1) * naviSize + 1;
         endPage = Math.min(beginPage + naviSize - 1 , totalPage);
         showPrev = beginPage != 1;
         showNext = endPage != totalPage;
+
+
+
     }
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 클라이언트 쪽에서 URL을 통해 파라미터 값을 임의로 변경해서 입력했을 경우, 의도하지 않은 값이 나오는 경우가 발생
* ex ) 총 페이지가 50 page인데 그것보다 큰 값을 넣거나 할 경우. 

# 어떻게 해결했나요?
* 현재 ``pageSize``(글 개수)선택은 5개, 10개 , 20개로 설정되어있습니다. 따라서 그것보다 큰 값을 입력할 경우 default 값인 5개로 출력되도록 설정했습니다.
* ``page``도 ``totalPage``(전체 페이지 개수)보다 큰 값을 입력했을 경우 마지막 페이지인 ``totalPage``로 이동할 수 있도록 설정했습니다.
* 원래 페이지 관련 파라미터를 관리하는 ``resolver``쪽에서 관리하는게 더 좋지 않을까 생각도 했었는데 pageSize는 상관없는데 page를 구하는 로직을 사용하기 위해서는 totalPage를 구해야해서 관련 코드가 있는 pageHandler 쪽 코드를 변경했습니다!
* 3항연산자를 사용하지 않고 if 문으로 처리한 이유는 if-else구문도 아니고 코드가 간단해서 가독성을 위해 그냥 if문으로 처리했습니다.

## Attachment
<img width="478" alt="KakaoTalk_Photo_2022-04-29-11-15-58" src="https://user-images.githubusercontent.com/95499211/165889785-bd8b137b-24b1-45c5-b961-ec9f90f0eac5.png">

<img width="1304" alt="KakaoTalk_Photo_2022-04-29-12-11-42" src="https://user-images.githubusercontent.com/95499211/165889789-ea1d85a1-bcaf-40cb-9046-4075f95cfba3.png">