### PR TITLE
feature : xss 방어 코드 작성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-data-redis</artifactId>
         </dependency>
+        <!-- xss 방어를 위한 lucy-filter -->
+        <dependency>
+            <groupId>com.navercorp.lucy</groupId>
+            <artifactId>lucy-xss-servlet</artifactId>
+            <version>2.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/hoin/boardStudy/board/config/WebMvcConfigure.java
+++ b/src/main/java/com/hoin/boardStudy/board/config/WebMvcConfigure.java
@@ -2,7 +2,9 @@ package com.hoin.boardStudy.board.config;
 
 import com.hoin.boardStudy.board.config.filter.LoginCheck;
 import com.hoin.boardStudy.board.config.handler.PageRequestHandler;
+import com.navercorp.lucy.security.xss.servletfilter.XssEscapeServletFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -30,4 +32,13 @@ public class WebMvcConfigure implements WebMvcConfigurer {
         return filterRegistrationBean;
     }
 
+    // xss 방어 코드
+    @Bean
+    public FilterRegistrationBean<XssEscapeServletFilter> filterRegistrationBean() {
+        FilterRegistrationBean<XssEscapeServletFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new XssEscapeServletFilter());
+        filterRegistrationBean.setOrder(2);
+        filterRegistrationBean.addUrlPatterns("/*");
+        return filterRegistrationBean;
+    }
 }

--- a/src/main/resources/lucy-xss-servlet-filter-rule.xml
+++ b/src/main/resources/lucy-xss-servlet-filter-rule.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<config xmlns="http://www.navercorp.com/lucy-xss-servlet">
+    <defenders>
+        <!-- XssPreventer 등록 -->
+        <defender>
+            <name>xssPreventerDefender</name>
+            <class>com.navercorp.lucy.security.xss.servletfilter.defender.XssPreventerDefender</class>
+        </defender>
+
+        <!-- XssSaxFilter 등록 -->
+        <defender>
+            <name>xssSaxFilterDefender</name>
+            <class>com.navercorp.lucy.security.xss.servletfilter.defender.XssSaxFilterDefender</class>
+            <init-param>
+                <param-value>lucy-xss-sax.xml</param-value>   <!-- lucy-xss-filter의 sax용 설정파일 -->
+                <param-value>false</param-value>        <!-- 필터링된 코멘트를 남길지 여부, 성능 효율상 false 추천 -->
+            </init-param>
+        </defender>
+
+        <!-- XssFilter 등록 -->
+        <defender>
+            <name>xssFilterDefender</name>
+            <class>com.navercorp.lucy.security.xss.servletfilter.defender.XssFilterDefender</class>
+            <init-param>
+                <param-value>lucy-xss.xml</param-value>    <!-- lucy-xss-filter의 dom용 설정파일 -->
+                <param-value>false</param-value>         <!-- 필터링된 코멘트를 남길지 여부, 성능 효율상 false 추천 -->
+            </init-param>
+        </defender>
+    </defenders>
+
+    <!-- default defender 선언, 필터링 시 지정한 defender가 없으면 여기 정의된 default defender를 사용해 필터링 한다. -->
+    <default>
+        <defender>xssPreventerDefender</defender>
+    </default>
+
+    <!-- global 필터링 룰 선언 -->
+    <global>
+        <!-- 모든 url에서 들어오는 globalParameter 파라메터는 필터링 되지 않으며
+                또한 globalPrefixParameter1로 시작하는 파라메터도 필터링 되지 않는다.
+                globalPrefixParameter2는 필터링 되며 globalPrefixParameter3은 필터링 되지 않지만
+                더 정확한 표현이 가능하므로 globalPrefixParameter2, globalPrefixParameter3과 같은 불분명한 표현은 사용하지 않는 것이 좋다. -->
+        <params>
+            <param name="globalParameter" useDefender="false" />
+            <param name="globalPrefixParameter1" usePrefix="true" useDefender="false" />
+            <param name="globalPrefixParameter2" usePrefix="true" />
+            <param name="globalPrefixParameter3" usePrefix="false" useDefender="false" />
+        </params>
+    </global>
+
+    <!-- url 별 필터링 룰 선언 -->
+    <url-rule-set>
+
+        <!-- url disable이 true이면 지정한 url 내의 모든 파라메터는 필터링 되지 않는다. -->
+        <url-rule>
+            <url disable="true">/disableUrl1.do</url>
+        </url-rule>
+
+        <!-- url disable이 false인 설정은 기본이기 때문에 불필요하다. 아래와 같은 불필요한 설정은 하지 않는다.-->
+        <url-rule>
+            <url disable="false">/disableUrl2.do</url>
+        </url-rule>
+
+        <!-- url disable이 true이면 지정한 url 내의 모든 파라메터가 필터링 되지 않기 때문에 <params> 로 선언한 설정은 적용되지 않는다.
+               아래와 같은 불필요한 설정은 하지 않는다. -->
+        <url-rule>
+            <url disable="true">/disableUrl3.do</url>
+            <params>
+                <param name="query" useDefender="false" />
+                <param name="prefix1" usePrefix="true" />
+                <param name="prefix2" usePrefix="false" useDefender="false" />
+                <param name="prefix3" usePrefix="true" useDefender="true" />
+                <param name="prefix4" usePrefix="true" useDefender="false" />
+                <param name="prefix5" usePrefix="false" useDefender="true" />
+            </params>
+        </url-rule>
+
+        <!-- url disable이 false인 설정은 기본이기 때문에 불필요하다. <params> 선언한 설정은 적용이 된다.-->
+        <url-rule>
+            <url disable="false">/disableUrl4.do</url>
+            <params>
+                <!-- disableUrl4.do 의 query 파라메터와 prefix4로 시작하는 파라메터들은 필터링 되지 않는다.
+                        usePrefix가 false, useDefender가 true인 설정은 기본이기 때문에 불필요하다. -->
+                <param name="query" useDefender="false" />
+                <param name="prefix1" usePrefix="true" />
+                <param name="prefix2" usePrefix="false" useDefender="false" />
+                <param name="prefix3" usePrefix="true" useDefender="true" />
+                <param name="prefix4" usePrefix="true" useDefender="false" />
+                <param name="prefix5" usePrefix="false" useDefender="true" />
+            </params>
+        </url-rule>
+
+        <!-- url1 내의 url1Parameter는 필터링 되지 않으며 또한 url1PrefixParameter로 시작하는 파라메터도 필터링 되지 않는다. -->
+        <url-rule>
+            <url>/url1.do</url>
+            <params>
+                <param name="url1Parameter" useDefender="false" />
+                <param name="url1PrefixParameter" usePrefix="true" useDefender="false" />
+            </params>
+        </url-rule>
+
+        <!-- url2 내의 url2Parameter1만 필터링 되지 않으며 url2Parameter2는 xssSaxFilterDefender를 사용해 필터링 한다.  -->
+        <url-rule>
+            <url>/url2.do</url>
+            <params>
+                <param name="url2Parameter1" useDefender="false" />
+                <param name="url2Parameter2">
+                    <defender>xssSaxFilterDefender</defender>
+                </param>
+            </params>
+        </url-rule>
+    </url-rule-set>
+</config>

--- a/src/main/resources/lucy-xss-superset-sax.xml
+++ b/src/main/resources/lucy-xss-superset-sax.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<config xmlns="http://www.nhncorp.com/lucy-xss"
+        extends="lucy-xss-default-sax.xml">
+
+    <elementRule>
+        <element name="body" disable="true" /> <!-- <BODY ONLOAD=alert("XSS")>, <BODY BACKGROUND="javascript:alert('XSS')"> -->
+        <element name="embed" disable="true" />
+        <element name="iframe" disable="true" /> <!-- <IFRAME SRC=”http://hacker-site.com/xss.html”> -->
+        <element name="meta" disable="true" />
+        <element name="object" disable="true" />
+        <element name="script" disable="true" /> <!-- <SCRIPT> alert(“XSS”); </SCRIPT> -->
+        <element name="style" disable="true" />
+        <element name="link" disable="true" />
+        <element name="base" disable="true" />
+    </elementRule>
+
+    <attributeRule>
+        <attribute name="data" base64Decoding="true">
+            <notAllowedPattern><![CDATA[(?i:s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[(?i:d\\*a\\*t\\*a\\*:)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+        </attribute>
+        <attribute name="src" base64Decoding="true">
+            <notAllowedPattern><![CDATA[(?i:s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[(?i:d\\*a\\*t\\*a\\*:)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+        </attribute>
+        <attribute name="style">
+            <notAllowedPattern><![CDATA[(?i:j\\*a\\*v\\*a\\*s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[(?i:e\\*x\\*p\\*r\\*e\\*s\\*s\\*i\\*o\\*n)]]></notAllowedPattern>
+            <notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+        </attribute>
+        <attribute name="href">
+            <notAllowedPattern><![CDATA[(?i:j\\*a\\*v\\*a\\*s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+        </attribute>
+    </attributeRule>
+
+</config>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -23,13 +23,13 @@
                 <th style="width:15%" class="table-active text-center">작성일</th><td style="width:35%" th:text="${#temporals.format(detail.regDate, 'yyyy-MM-dd HH:mm')}"></td>
             </tr>
             <tr>
-                <th style="width:15%" class="table-active text-center">제목</th><td th:text="${detail.title}"></td>
+                <th style="width:15%" class="table-active text-center">제목</th><td th:utext="${detail.title}"></td>
                 <th style="width:15%" class="table-active text-center">수정일</th><td th:text="${#temporals.format(detail.updDate, 'yyyy-MM-dd HH:mm')}"></td>
             </tr>
             <tr>
                 <td colspan="4" style="height:100%">
                     <!-- textarea 색상, 클릭, 수정, 크기 조절 불가-->
-                    <textarea class="form-control" rows="20" style="border: none; resize: none; background-color:white" th:text="${detail.content}" disabled></textarea>
+                    <textarea class="form-control" rows="20" style="border: none; resize: none; background-color:white" th:utext="${detail.content}" disabled></textarea>
                 </td>
             </tr>
         </table>

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -49,7 +49,7 @@
             <tr th:if="${#lists.size(list)} > 0" th:each="list : ${list}">
                 <th scope="row" th:text="${list.boardId}"></th>
                 <td>
-                    <a href="/board/detail.do?boardId=" th:attrappend="href=${list.boardId}" th:text="${list.title}"></a>
+                    <a href="/board/detail.do?boardId=" th:attrappend="href=${list.boardId}" th:utext="${list.title}"></a>
                     <img src="/images/new.png" alt="new" style="width: 20px; height: 20px" th:if="${list.newCheck} == true">
                 </td>
                 <td th:text="${list.writer}"></td>

--- a/src/main/resources/templates/board/modify.html
+++ b/src/main/resources/templates/board/modify.html
@@ -44,9 +44,9 @@
                     <input type="hidden" id="fileId" name="fileId" th:value="${fileInfo.fileId}"/>
                 </if>
                 <tr><th>제목</th></tr>
-                <tr><td width="90%"><input name="title" id="title" class="form-control" th:value="${board.title}" required="required" ></td></tr>
+                <tr><td width="90%"><textarea name="title" id="title" class="form-control" th:utext="${board.title}" maxlength="30" required="required" style="resize: none; height: 30px; background-color:white"></textarea></td></tr>
                 <tr><th>내용</th></tr>
-                <tr><td class="text-center"><textarea class="form-control" name="content" id="content" th:text="${board.content}" maxlength="1500" rows="20" required="required" style="resize: none; background-color:white">내용을 입력하세요.</textarea></td></tr>
+                <tr><td class="text-center"><textarea class="form-control" name="content" id="content" th:utext="${board.content}" maxlength="1500" rows="20" required="required" style="resize: none; background-color:white">내용을 입력하세요.</textarea></td></tr>
                 <tr>
                     <td>
                         <div class="input-group">


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* XSS 공격 방어

# 어떻게 해결했나요?
* 일단 들어가기 전에.. thymeleaf에는 자체적으로 ``th:text``기능을 사용하면 xss 방어가 된다고 합니다.. ㅎㅎㅎ
* 그래서 따로 적용할 필요가 있을까 고민.
* 하지만 일단 **요청받을 때 검증되지 않은 값을 허용하는 것 자체가 문제**라고 생각이 들어서 필터를 적용하기로 했습니다.
* 필터는 자체적으로 만들 수도 있지만, 공격의 경우의 수는 너무나 많기도 하고 이미 잘 설계되어있고 테스팅을 많이 거친 오픈 소스가 있기 때문에 네이버에서 만든 ``lucy-xss-servlet``를 사용하기로 결정했습니다.

github에 나와있는 lucy 장단점 
> XML 설정 만으로 XSS 방어가 가능하다.
비지니스 레이어의 코드 수정이 발생하지 않는다.
개발자가 XSS 방어를 신경 쓰지 않아도 된다.
XSS 방어가 누락되지 않는다.
설정 파일 하나로 XSS 방어절차가 파악 된다.
파라메터명에 대해 관리가 필요해진다.
일괄 적용되어 영향 받기 때문에 정확한 필터링 룰 정의가 중요하다.

1. pom.xml 에 lucy-xss-servlet 의존성 추가.
2. filter-rule 과 같은 https://github.com/naver/lucy-xss-servlet-filter에 나와잇는 xml 파일 생성
3. webconfig 에 필터 등록
--> 여기까지하면 DB에는 정상적으로 <,>," 등이 잘 치환되어 들어갑니다.
4. 화면에 출력할 때는 &lt 이런 식으로 출력할 수 없기 때문에, thymeleaf의 th:utext 기능을 활용해줍니다.
5.원래 수정 페이지 제목은 ``ìnput``에 등록 되어있던 제목을 value 값을 넣어 사용하고 있었는데 이 경우 utext 를 사용할 수 없기 때문에 <textarea>태그로 변경하고 크기를 맞게 조절해주었습니다.

## Attachment
* https://dev-yujji.tistory.com/56
* https://jaeseongdev.github.io/development/2021/05/20/XSS/

+ 필터 적용 전
<img width="814" alt="image" src="https://user-images.githubusercontent.com/95499211/166212530-bca957e3-7fe8-4e9d-9b83-33e17f7fc81a.png">

+ 필터 적용 후 
 
<img width="813" alt="image" src="https://user-images.githubusercontent.com/95499211/166212420-263d6291-64e5-410f-ab3c-d56dc0f48b52.png">

