### PR TITLE
알람 서비스 구현

### DIFF
--- a/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
+++ b/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
@@ -6,6 +6,7 @@ import com.hoin.boardStudy.board.service.BoardService;
 import com.hoin.boardStudy.board.service.FileManager;
 import com.hoin.boardStudy.board.service.ViewCountUpdater;
 import com.hoin.boardStudy.user.dto.User;
+import com.hoin.boardStudy.user.service.EmailManagement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -31,6 +32,7 @@ public class BoardController {
     private final BoardService boardService;
     private final FileManager fileManager;
     private final ViewCountUpdater viewCountUpdater;
+    private final EmailManagement emailManagement;
 
     // 전체 글 조회
     @GetMapping("list.do")

--- a/src/main/java/com/hoin/boardStudy/board/controller/CommentController.java
+++ b/src/main/java/com/hoin/boardStudy/board/controller/CommentController.java
@@ -2,8 +2,10 @@ package com.hoin.boardStudy.board.controller;
 
 import com.hoin.boardStudy.board.dto.Comment;
 import com.hoin.boardStudy.board.dto.ModifyRequest;
+import com.hoin.boardStudy.board.service.BoardService;
 import com.hoin.boardStudy.board.service.CommentManager;
 import com.hoin.boardStudy.user.dto.User;
+import com.hoin.boardStudy.user.service.EmailManagement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,8 @@ import java.util.List;
 public class CommentController {
 
     private final CommentManager commentManager;
+    private final EmailManagement emailManagement;
+    private final BoardService boardService;
 
     // 댓글 목록
     @GetMapping("/{boardId}")
@@ -30,9 +34,15 @@ public class CommentController {
     // 댓글 입력
     @PostMapping
     public void insertComment(@RequestBody Comment comment, HttpSession session) {
-        String writer = ((User) session.getAttribute("user")).getUserId();
-        comment.setCommenter(writer);
-        commentManager.insertComment(comment, writer);
+        String commenter = ((User) session.getAttribute("user")).getUserId();
+
+        int boardId = comment.getBoardId();
+        User articleWriter = boardService.getWriter(boardId);
+        String to = articleWriter.getEmail();
+
+        comment.setCommenter(commenter);
+        commentManager.insertComment(comment, commenter);
+        emailManagement.sendMail(to,comment);
     }
 
 

--- a/src/main/java/com/hoin/boardStudy/board/controller/CommentController.java
+++ b/src/main/java/com/hoin/boardStudy/board/controller/CommentController.java
@@ -35,14 +35,11 @@ public class CommentController {
     @PostMapping
     public void insertComment(@RequestBody Comment comment, HttpSession session) {
         String commenter = ((User) session.getAttribute("user")).getUserId();
-
-        int boardId = comment.getBoardId();
-        User articleWriter = boardService.getWriter(boardId);
-        String to = articleWriter.getEmail();
-
         comment.setCommenter(commenter);
+
         commentManager.insertComment(comment, commenter);
-        emailManagement.sendMail(to,comment);
+        emailManagement.sendMail(comment);
+
     }
 
 

--- a/src/main/java/com/hoin/boardStudy/board/mapper/BoardMapper.java
+++ b/src/main/java/com/hoin/boardStudy/board/mapper/BoardMapper.java
@@ -2,6 +2,7 @@ package com.hoin.boardStudy.board.mapper;
 
 import com.hoin.boardStudy.board.dto.Board;
 import com.hoin.boardStudy.board.dto.FileInfo;
+import com.hoin.boardStudy.user.dto.User;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -41,5 +42,8 @@ public interface BoardMapper {
 
     // 파일 정보 가져오기
     FileInfo getFileInfo(int fileId);
+
+    // 작성자 정보 가져오기
+    User getWriter(int boardId);
 
 }

--- a/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
+++ b/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.hoin.boardStudy.board.service;
 import com.hoin.boardStudy.board.dto.BoardSaveRequest;
 import com.hoin.boardStudy.board.mapper.BoardMapper;
 import com.hoin.boardStudy.board.dto.Board;
+import com.hoin.boardStudy.user.dto.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -82,5 +83,11 @@ public class BoardService {
     @Transactional
     public void deleteBoard(int boardId) {
         boardMapper.deleteBoard(boardId);
+    }
+
+    // 작성자 정보
+    @Transactional
+    public User getWriter(int boardId) {
+        return boardMapper.getWriter(boardId);
     }
 }

--- a/src/main/java/com/hoin/boardStudy/user/service/EmailManagement.java
+++ b/src/main/java/com/hoin/boardStudy/user/service/EmailManagement.java
@@ -1,7 +1,9 @@
 package com.hoin.boardStudy.user.service;
 
 import com.hoin.boardStudy.board.dto.Comment;
+import com.hoin.boardStudy.board.service.BoardService;
 import com.hoin.boardStudy.user.dto.DomainProperties;
+import com.hoin.boardStudy.user.dto.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -18,6 +20,7 @@ public class EmailManagement { // 이메일 재사용성을 위해 분리
 
     private final JavaMailSender javaMailSender;
     private final DomainProperties domainProperties;
+    private final BoardService boardService;
 
     public void sendMail(String to,String key) {
 
@@ -34,21 +37,28 @@ public class EmailManagement { // 이메일 재사용성을 위해 분리
         }
     }
 
-    public void sendMail(String to, Comment comment) {
+    public void sendMail(Comment comment) {
 
         String commenter = comment.getCommenter();
         String title = commenter + "님이 댓글을 남겼습니다.";
 
-        try {
-            MimeMessage mail = javaMailSender.createMimeMessage();
-            MimeMessageHelper mailHelper = new MimeMessageHelper(mail,"UTF-8");
-            mailHelper.setFrom(FROM);
-            mailHelper.setTo(to);
-            mailHelper.setSubject(title);
-            mailHelper.setText(commenter + "님이 " + comment.getComment() + "라고 댓글을 남겼습니다.");
-            javaMailSender.send(mail);
-        } catch (Exception e) {
-            e.printStackTrace();
+        int boardId = comment.getBoardId();
+        User articleWriter = boardService.getWriter(boardId);
+        String to = articleWriter.getEmail();
+        String writer = articleWriter.getUserId();
+
+        if(!commenter.equals(writer)) {
+            try {
+                MimeMessage mail = javaMailSender.createMimeMessage();
+                MimeMessageHelper mailHelper = new MimeMessageHelper(mail, "UTF-8");
+                mailHelper.setFrom(FROM);
+                mailHelper.setTo(to);
+                mailHelper.setSubject(title);
+                mailHelper.setText(commenter + "님이 " + comment.getComment() + "라고 댓글을 남겼습니다.");
+                javaMailSender.send(mail);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/com/hoin/boardStudy/user/service/EmailManagement.java
+++ b/src/main/java/com/hoin/boardStudy/user/service/EmailManagement.java
@@ -1,5 +1,6 @@
 package com.hoin.boardStudy.user.service;
 
+import com.hoin.boardStudy.board.dto.Comment;
 import com.hoin.boardStudy.user.dto.DomainProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,24 @@ public class EmailManagement { // 이메일 재사용성을 위해 분리
             mailHelper.setTo(to);
             mailHelper.setSubject(TITLE);
             mailHelper.setText(String.format(CONTENT,domainProperties.getName(),to,key), true);
+            javaMailSender.send(mail);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void sendMail(String to, Comment comment) {
+
+        String commenter = comment.getCommenter();
+        String title = commenter + "님이 댓글을 남겼습니다.";
+
+        try {
+            MimeMessage mail = javaMailSender.createMimeMessage();
+            MimeMessageHelper mailHelper = new MimeMessageHelper(mail,"UTF-8");
+            mailHelper.setFrom(FROM);
+            mailHelper.setTo(to);
+            mailHelper.setSubject(title);
+            mailHelper.setText(commenter + "님이 " + comment.getComment() + "라고 댓글을 남겼습니다.");
             javaMailSender.send(mail);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/resources/mybatis/mapper/BoardMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardMapper.xml
@@ -132,7 +132,7 @@
 
     <!--작성자 정보 구하기-->
     <select id="getWriter" parameterType="int" resultType="user">
-        SELECT *
+        SELECT user_id as userId, email
         FROM TBL_USER
         WHERE user_id = (
             SELECT writer from TBL_BOARD

--- a/src/main/resources/mybatis/mapper/BoardMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardMapper.xml
@@ -130,4 +130,14 @@
         WHERE FILE_ID = #{fileId}
     </delete>
 
+    <!--작성자 정보 구하기-->
+    <select id="getWriter" parameterType="int" resultType="user">
+        SELECT *
+        FROM TBL_USER
+        WHERE user_id = (
+            SELECT writer from TBL_BOARD
+            WHERE board_id = #{boardId}
+        )
+    </select>
+
 </mapper>


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 댓글이 달리면 알람을 제공하는 서비스를 구현하고자 했습니다.

# 어떻게 해결했나요?
* 카톡, 텔레그램 등 다른 선택지도 많았지만, 이번 기회에 협업하는 동료가 쓴 코드를 보고 이해하고, 재사용하는 기회를 갖고자 했습니다.
* (사실 제대로 사용한 건지는 잘 모르겠습니다 ㅎㅎ..)
* 회원가입 시 다훈님이 작성한 ``EmailManagement``클래스를 사용했습니다. 이메일 관련 클래스이므로 찾기도 쉽고, 관리가 쉬울 것 같다고 생각했습니다.
* ``EmailManagement``의 ``sendMail()`` 메소드를 오버로딩해서 댓글을 작성할 때 댓글 정보를 넘겨주어 사용했습니다.
* 제일 고민한 것이 처음엔 컨트롤러에 글 작성자와 댓글 작성자 비교 코드도 있는 등 뭔가 정리가 안된 느낌이어서 최대한 책임을 분리하려고 노력했습니다. 컨트롤러가 지저분한 것 같아서 ``CommentManager`` 서비스로 넘겼다가 결국 다 정리해서 ``EmailManagement``안에서 정리했습니다.
* 글의 작성자의 정보를 가져오는 코드를 따로 작성했습니다. 이건  board와 관련이 있다고 생각해서 ``boardService``에 작성했습니다. 
* 본인이 작성한 글에 댓글을 달았을 땐 이메일 전송이 안 가도록 구현했습니다.

# Attachment
<img width="369" alt="image" src="https://user-images.githubusercontent.com/95499211/169028169-44cd5a39-6dc7-41ee-a41f-ac6bfbaba520.png">
