### PR TITLE
메소드 실행 시간을 측정하는 AOP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,12 @@
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <version>3.1.3</version>
         </dependency>
+
+        <!-- AOP -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/hoin/boardStudy/board/config/aop/MethodTimer.java
+++ b/src/main/java/com/hoin/boardStudy/board/config/aop/MethodTimer.java
@@ -1,0 +1,11 @@
+package com.hoin.boardStudy.board.config.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MethodTimer {
+}

--- a/src/main/java/com/hoin/boardStudy/board/config/aspect/ExecutionTimer.java
+++ b/src/main/java/com/hoin/boardStudy/board/config/aspect/ExecutionTimer.java
@@ -1,0 +1,36 @@
+package com.hoin.boardStudy.board.config.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionTimer {
+
+    @Pointcut("@annotation(com.hoin.boardStudy.board.config.aop.MethodTimer)")
+    private void timer(){};
+
+    @Around("timer()")
+    public void AssumeExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        joinPoint.proceed();
+        stopWatch.stop();
+
+        long totalTimeMillis = stopWatch.getTotalTimeMillis();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getMethod().getName();
+
+        log.info("실행 메서드 : {}, 실행시간 = {}ms", methodName, totalTimeMillis);
+    }
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* AOP에 대한 공부 후 실제로 적용해보기 위해 메소드 측정하는 AOP를 작성했습니다.
* 원래는 필터로 되어있는 로그인 체크하는 것을 리팩토링 하려 했으나 
1. 처음에 인터셉터 대신 필터를 사용한 것처럼 필터가 더 리턴이 빠름 (굳이 변경의 이유를 찾지 못함)
2. 평소에 측정 시간에 대해 궁금했음
이라는 이유로 메소드 실행 시간 측정하는 기능으로 변경했습니다.

# 어떻게 해결했나요?
* 일단 [간단한 AOP 적용 예제 (메서드 실행시간 측정)](https://velog.io/@dhk22/Spring-AOP-%EA%B0%84%EB%8B%A8%ED%95%9C-AOP-%EC%A0%81%EC%9A%A9-%EC%98%88%EC%A0%9C-%EB%A9%94%EC%84%9C%EB%93%9C-%EC%8B%A4%ED%96%89%EC%8B%9C%EA%B0%84-%EC%B8%A1%EC%A0%95) 블로그에 있는 예제를 보고 따라하고 모르는 코드들을 따로 찾아보는 식으로 진행했습니다.
1. pom.xml에 의존성 추가를 해줍니다.
2. 사용할 어노테이션에 대한 코드를 작성해줍니다. 여기서는 어노테이션이 붙은 메서드에 대해 수행하도록 설정했습니다.
3. AOP 클래스를 작성합니다. ``@Aspect``와 ``@Component``를 붙여 사용합니다.
4. 저번 포스팅에서 ``@PointCut``은 어디에 적용할지에 대한 정보라고 했습니다. 2에서 작성한 어노테이션으로 설정해줍니다.
5. 시간 측정이기 때문에 메서드 실행 전, 후로 공유해야 하므로 ``@Around`` 어노테이션을 사용해줍니다.
6. 실행 측정 로직을 작성해줍니다. ``MethodSignature`` 는 처음봐서 따로 찾아봤습니다. 메서드 이름과 매개변수 리스트를 제공한다고 합니다.
7. 측정할 메서드 위에 2번에서 작성한 어노테이션을 붙여주면 콘솔창에 실행 메서드 이름과 시간이 출력되게 됩니다.

## Attachment
* https://ijbgo.tistory.com/19

![image](https://user-images.githubusercontent.com/95499211/171136922-2bceacdf-a803-4398-aa83-043a71f43e27.png)

