### PR TITLE
@Async 어노테이션 적용하기

### DIFF
--- a/src/main/java/com/hoin/boardStudy/BoardApplication.java
+++ b/src/main/java/com/hoin/boardStudy/BoardApplication.java
@@ -3,12 +3,14 @@ package com.hoin.boardStudy;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableFeignClients
 @EnableRedisHttpSession
 @EnableSwagger2
+@EnableAsync
 @SpringBootApplication
 public class BoardApplication {
 

--- a/src/main/java/com/hoin/boardStudy/board/client/AlarmClient.java
+++ b/src/main/java/com/hoin/boardStudy/board/client/AlarmClient.java
@@ -5,7 +5,7 @@ import lombok.Value;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name="alarm", url = "http://"+"${domain.alarm}")
+@FeignClient(name="alarm", url = "https://"+"${domain.alarm}")
 public interface AlarmClient {
 
 

--- a/src/main/java/com/hoin/boardStudy/board/service/CommentManager.java
+++ b/src/main/java/com/hoin/boardStudy/board/service/CommentManager.java
@@ -11,6 +11,7 @@ import com.hoin.boardStudy.board.mapper.CommentMapper;
 import com.hoin.boardStudy.user.dto.DomainProperties;
 import com.hoin.boardStudy.user.dto.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +57,7 @@ public class CommentManager {
 
     // 알림 서비스 API 호출
     @Transactional
+    @Async
     public void alarmByEmail(Comment comment) {
 
         User articleWriter = boardMapper.getWriter(comment.getBoardId());


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 댓글 등록 시 , 이메일로 알람을 보내주는 서비스를 같이 적용하고 있습니다.
* 2가지 문제점
 1. 댓글을 등록하고 이메일 보내는 동작을 기다려야 댓글 완료 처리가 되어 시간이 생각보다 오래 걸려서 이 부분을 해결하고 싶었습니다.
 2. 댓글 등록이 주 서비스이기 때문에 , 댓글 등록이 완료되었는데 알람 서비스에 실패했다고 에러창을 보여주는 것은 문제점이는 조언이 있었고 , 이를 해결하고자 했습니다. 

# 어떻게 해결했나요?
*  비동기 동기의 개념만 알고 있고 실제로 적용할 생각을 못했는데, @DaeAkin 님의 조언 덕에 찾아보고 적용을 할 수 있었습니다. 

1. application 클래스에 ``@EnableAsync`` 달아주기
2. 비동기 처리할 메서드에 ``@Async`` 메서드를 달아주기

# 추가 전달 사항
+ 어제 배포한 알람 서비스 서버가 https인 관계로 https라고 따로 명시해주었습니다.

## Attachment
* https://velog.io/@gillog/Spring-Async-Annotation%EB%B9%84%EB%8F%99%EA%B8%B0-%EB%A9%94%EC%86%8C%EB%93%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
