### PR TITLE
이전 글, 다음 글 구현

### DIFF
--- a/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
+++ b/src/main/java/com/hoin/boardStudy/board/controller/BoardController.java
@@ -66,6 +66,7 @@ public class BoardController {
     public String getDetailPage(@RequestParam int boardId, Model model) {
         model.addAttribute("detail", boardService.getDetail(boardId));
         model.addAttribute("fileInfo", fileManager.getFiles(boardId));
+        model.addAttribute("move", boardService.getPageToMove(boardId));
         viewCountUpdater.increaseViewCount(boardId);
         return "board/detail";
     }

--- a/src/main/java/com/hoin/boardStudy/board/dto/PrevAndNext.java
+++ b/src/main/java/com/hoin/boardStudy/board/dto/PrevAndNext.java
@@ -10,8 +10,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PrevAndNext {
-    int prev;
-    int next;
-    String prevTitle;
-    String nextTitle;
+    private int prev;
+    private int next;
+    private String prevTitle;
+    private String nextTitle;
 }

--- a/src/main/java/com/hoin/boardStudy/board/dto/PrevAndNext.java
+++ b/src/main/java/com/hoin/boardStudy/board/dto/PrevAndNext.java
@@ -1,0 +1,17 @@
+package com.hoin.boardStudy.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrevAndNext {
+    int prev;
+    int next;
+    String prevTitle;
+    String nextTitle;
+}

--- a/src/main/java/com/hoin/boardStudy/board/mapper/BoardMapper.java
+++ b/src/main/java/com/hoin/boardStudy/board/mapper/BoardMapper.java
@@ -2,6 +2,7 @@ package com.hoin.boardStudy.board.mapper;
 
 import com.hoin.boardStudy.board.dto.Board;
 import com.hoin.boardStudy.board.dto.FileInfo;
+import com.hoin.boardStudy.board.dto.PrevAndNext;
 import com.hoin.boardStudy.user.dto.User;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -46,4 +47,9 @@ public interface BoardMapper {
     // 작성자 정보 가져오기
     User getWriter(int boardId);
 
+    // 이전 페이지
+    Board getPrevPage(int boardId);
+
+    // 다음 페이지
+    Board getNextPage(int boardId);
 }

--- a/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
+++ b/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
@@ -19,6 +19,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BoardService {
 
+    private static final String NO_PREV = "이전 글이 없습니다.";
+    private static final String NO_NEXT = "다음 글이없습니다.";
+
     private final BoardMapper boardMapper;
     private final NewArticleChecker newArticleChecker;
     private final CommentManager commentManager;
@@ -106,53 +109,26 @@ public class BoardService {
     }
     
     // 이전 글 게시물 번호
-    @Transactional
-    int getPrevBoardId(int boardId) {
-        int prev = 0;
-
-        if(boardMapper.getPrevPage(boardId) != null) {
-            prev = boardMapper.getPrevPage(boardId).getBoardId();
-        }
-
-        return prev;
+    private int getPrevBoardId(int boardId) {
+        if(boardMapper.getPrevPage(boardId) != null) return boardMapper.getPrevPage(boardId).getBoardId();
+        return 0;
     }
-    
+
     // 이전 글 게시물 제목
-    @Transactional
-    String getPrevTitle(int boardId) {
-        String prevTitle = "이전 글이 없습니다.";
-
-        if(boardMapper.getPrevPage(boardId) != null) {
-            prevTitle = boardMapper.getPrevPage(boardId).getTitle();
-        }
-
-        return prevTitle;
+    private String getPrevTitle(int boardId) {
+        if(boardMapper.getPrevPage(boardId) != null) return boardMapper.getPrevPage(boardId).getTitle();
+        return NO_PREV;
     }
     
     // 다음 글 게시물 번호
-    @Transactional
-    int getNextBoardId(int boardId) {
-        int next = 0;
-
-        if(boardMapper.getNextPage(boardId) != null) {
-            next = boardMapper.getNextPage(boardId).getBoardId();
-        }
-
-        return next;
+    private int getNextBoardId(int boardId) {
+        if(boardMapper.getNextPage(boardId) != null) return boardMapper.getNextPage(boardId).getBoardId();
+        return 0;
     }
     
     // 다음 글 게시판 제목
-    @Transactional
-    String getNextTitle(int boardId) {
-
-        String nextTitle = "다음 글이 없습니다.";
-
-        if(boardMapper.getNextPage(boardId) != null) {
-            nextTitle = boardMapper.getNextPage(boardId).getTitle();
-        }
-
-        return nextTitle;
+    private String getNextTitle(int boardId) {
+        if(boardMapper.getNextPage(boardId) != null) return boardMapper.getNextPage(boardId).getTitle();
+        return NO_NEXT;
     }
-
-
 }

--- a/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
+++ b/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
@@ -95,25 +95,64 @@ public class BoardService {
     @Transactional
     public PrevAndNext getPageToMove(int boardId) {
 
-        int prev = 0;
-        int next = 0;
-        String prevTitle = "이전 글이 없습니다.";
-        String nextTitle = "다음 글이 없습니다.";
-
-        // 이전 글이 존재할 경우
-        if(boardMapper.getPrevPage(boardId) != null) {
-            prev = boardMapper.getPrevPage(boardId).getBoardId();
-            prevTitle = boardMapper.getPrevPage(boardId).getTitle();
-        }
-
-        // 다음 글이 존재할 경우
-        if(boardMapper.getNextPage(boardId) != null) {
-            next = boardMapper.getNextPage(boardId).getBoardId();
-            nextTitle = boardMapper.getNextPage(boardId).getTitle();
-        }
+        int prev = getPrevBoardId(boardId);
+        int next = getNextBoardId(boardId);
+        String prevTitle = getPrevTitle(boardId);
+        String nextTitle = getNextTitle(boardId);
 
         PrevAndNext prevAndNext = new PrevAndNext(prev, next, prevTitle, nextTitle);
 
         return prevAndNext;
     }
+    
+    // 이전 글 게시물 번호
+    @Transactional
+    int getPrevBoardId(int boardId) {
+        int prev = 0;
+
+        if(boardMapper.getPrevPage(boardId) != null) {
+            prev = boardMapper.getPrevPage(boardId).getBoardId();
+        }
+
+        return prev;
+    }
+    
+    // 이전 글 게시물 제목
+    @Transactional
+    String getPrevTitle(int boardId) {
+        String prevTitle = "이전 글이 없습니다.";
+
+        if(boardMapper.getPrevPage(boardId) != null) {
+            prevTitle = boardMapper.getPrevPage(boardId).getTitle();
+        }
+
+        return prevTitle;
+    }
+    
+    // 다음 글 게시물 번호
+    @Transactional
+    int getNextBoardId(int boardId) {
+        int next = 0;
+
+        if(boardMapper.getNextPage(boardId) != null) {
+            next = boardMapper.getNextPage(boardId).getBoardId();
+        }
+
+        return next;
+    }
+    
+    // 다음 글 게시판 제목
+    @Transactional
+    String getNextTitle(int boardId) {
+
+        String nextTitle = "다음 글이 없습니다.";
+
+        if(boardMapper.getNextPage(boardId) != null) {
+            nextTitle = boardMapper.getNextPage(boardId).getTitle();
+        }
+
+        return nextTitle;
+    }
+
+
 }

--- a/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
+++ b/src/main/java/com/hoin/boardStudy/board/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.hoin.boardStudy.board.service;
 
 import com.hoin.boardStudy.board.dto.BoardSaveRequest;
+import com.hoin.boardStudy.board.dto.PrevAndNext;
 import com.hoin.boardStudy.board.mapper.BoardMapper;
 import com.hoin.boardStudy.board.dto.Board;
 import com.hoin.boardStudy.user.dto.User;
@@ -18,7 +19,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BoardService {
 
-    private final BoardMapper boardMapper; // RequiredArgsConstructor 사용 (생성자 주입)
+    private final BoardMapper boardMapper;
     private final NewArticleChecker newArticleChecker;
     private final CommentManager commentManager;
 
@@ -53,7 +54,6 @@ public class BoardService {
      */
     @Transactional(readOnly = true)
     public Board getDetail(int boardId) {
-
         return boardMapper.getDetail(boardId);
     }
 
@@ -89,5 +89,31 @@ public class BoardService {
     @Transactional
     public User getWriter(int boardId) {
         return boardMapper.getWriter(boardId);
+    }
+
+    // 페이지 이동
+    @Transactional
+    public PrevAndNext getPageToMove(int boardId) {
+
+        int prev = 0;
+        int next = 0;
+        String prevTitle = "이전 글이 없습니다.";
+        String nextTitle = "다음 글이 없습니다.";
+
+        // 이전 글이 존재할 경우
+        if(boardMapper.getPrevPage(boardId) != null) {
+            prev = boardMapper.getPrevPage(boardId).getBoardId();
+            prevTitle = boardMapper.getPrevPage(boardId).getTitle();
+        }
+
+        // 다음 글이 존재할 경우
+        if(boardMapper.getNextPage(boardId) != null) {
+            next = boardMapper.getNextPage(boardId).getBoardId();
+            nextTitle = boardMapper.getNextPage(boardId).getTitle();
+        }
+
+        PrevAndNext prevAndNext = new PrevAndNext(prev, next, prevTitle, nextTitle);
+
+        return prevAndNext;
     }
 }

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -10,5 +10,6 @@
         <typeAlias alias="modifyRequest" type="com.hoin.boardStudy.board.dto.ModifyRequest"/>
         <typeAlias alias="user" type="com.hoin.boardStudy.user.dto.User"/>
         <typeAlias alias="userAuth" type="com.hoin.boardStudy.user.dto.UserAuth"/>
+        <typeAlias alias="prevAndNext" type="com.hoin.boardStudy.board.dto.PrevAndNext"/>
     </typeAliases>
 </configuration>

--- a/src/main/resources/mybatis/mapper/BoardMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardMapper.xml
@@ -157,7 +157,7 @@
             from TBL_BOARD
             where board_id > ${boardId}
             ORDER BY board_id
-            DESC LIMIT 1
+            LIMIT 1
         ]]>
     </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/BoardMapper.xml
+++ b/src/main/resources/mybatis/mapper/BoardMapper.xml
@@ -26,7 +26,6 @@
         <result column="path" property="path"/>
     </resultMap>
 
-
     <!--게시판 목록 전체 조회하기-->
     <select id="getBoardList" parameterType="map" resultMap="boardMap">
         SELECT *
@@ -140,4 +139,25 @@
         )
     </select>
 
+    <!-- 이전 페이지 -->
+    <select id="getPrevPage" parameterType="int" resultMap="boardMap">
+        <![CDATA[
+            select board_id, title
+            from TBL_BOARD
+            where board_id < ${boardId}
+            ORDER BY board_id
+            DESC LIMIT 1
+        ]]>
+    </select>
+
+    <!-- 다음 페이지-->
+    <select id="getNextPage" parameterType="int" resultMap="boardMap">
+        <![CDATA[
+            select board_id, title
+            from TBL_BOARD
+            where board_id > ${boardId}
+            ORDER BY board_id
+            DESC LIMIT 1
+        ]]>
+    </select>
 </mapper>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -55,6 +55,24 @@
         </if>
         <button type="button" class="btn btn-secondary" onclick="location.href='list.do'">목록</button>
 
+        <div class="form-group">
+            <if th:if="${move.getPrev() != 0}">
+                이전 글 : <a th:href="@{/board/detail.do(boardId=${move.getPrev()})} " th:utext="${move.getPrevTitle()}"></a>
+            </if>
+            <if th:if="${move.getPrev() == 0}">
+                이전 글 : <a th:utext="${move.getPrevTitle()}"></a>
+            </if>
+        </div>
+        <div class="form-group">
+            <if th:if="${move.getNext() != 0}">
+                다음 글 : <a th:href="@{/board/detail.do(boardId=${move.getNext()})} " th:utext="${move.getNextTitle()}"></a>
+            </if>
+            <if th:if="${move.getNext() == 0}">
+                다음 글 : <a th:utext="${move.getNextTitle()}"></a>
+            </if>
+        </div>
+
+
         <div class="commentList" id="commentList" name="commentList" style="margin-top: 30px; margin-right: 200px">
         </div>
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 현재 보고 있는 페이지에서 이전 글, 다음 글로 이동할 수 있는 기능을 구현하려고 했습니다.

# 어떻게 해결했나요?

### 1

페이지 이동을 위해 현재 페이지 기준 이전, 다음 글의 
  - 게시물 번호와 (board_id)
  - 편의성을 위해 제목 (title)
두 가지 항목을 가져오고자 했습니다.

### 2

 ``PrevAndNext`` 라는 dto를 생성하여 가져온 번호와 제목을 model에 담아 넘겨주었습니다.

### 3

화면엔 기본적으로 
이전 글 : 
다음 글 : 
의 형식을 가지고 표시하였습니다.

게시물이 존재할 경우 
- 제목이 표시되며 a 태그를 활용해 해당 게시물로 넘어갈 수 있도록 진행하였습니다.

게시물이 존재하지 않을 경우
-  p 태그를 활용해 이전 / 다음 글이 존재하지 않는다고 표시하였습니다.

![image](https://user-images.githubusercontent.com/95499211/189161767-1a8927f1-8f03-4d3a-938f-d42474e71b1f.png)

! 주의점 

+ 현재 글 기준 > , <  기호를 사용하기 때문에 mybatis 사용시 <![CDATA[]}> 를 사용해서 태그로 인식하는 것을 방지해주어야합니다.

## Attachment
* https://gdtbgl93.tistory.com/53
* https://graykim.tistory.com/218
